### PR TITLE
shell.nix: Allow Nix users to skip virtualenv or system pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ user_timeline
 favorites
 memberships
 subscriptions
+/result

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,10 @@
+let
+  bootPkgs = import <nixpkgs> {};
+  pinnedPkgs = bootPkgs.fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs-channels";
+    rev = "c29d2fde74d03178ed42655de6dee389f2b7d37f";
+    sha256 = "1v1cnlhqp6lcjbsakyiaqk2mm21gdj74d1i7g75in02ykk5xnc7k";
+  };
+in
+import pinnedPkgs

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import ./nixpkgs.nix {}
+, mkShell ? pkgs.mkShell
+, fetchurl ? pkgs.fetchurl
+, python2 ? pkgs.python2
+}:
+
+mkShell {
+  buildInputs = [(python2.withPackages (pypkgs: with pypkgs; [
+    lxml
+    (requests.overridePythonAttrs (oldAttrs: rec {
+      name = "requests-0.14.2";
+      src = fetchurl {
+        url = "mirror://pypi/r/requests/${name}.tar.gz";
+        sha256 = "1vxa38x0lm6l7jcn5av54abmy3052mj2glyrggqjnw8dmjl4acqf";
+      };
+    }))
+    python-dateutil
+  ]))];
+}


### PR DESCRIPTION
If you have Nix installed, you can call the script with just:
nix-shell --run `./StatusNet-Backup.py --endpoint foo --user bar`

Or, you can just run `nix-shell` to get into an interactive shell with
the right Python and packages in the environment, and then run
`./StatusNet-Backup.py --endpoint foo --user bar`

nixpkgs.nix is nixpkgs pinned to a known-working version.